### PR TITLE
Add Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,12 @@
 
 launch.json
 
+# External assets repo
+/assets/
 
 # Build output directories
 /build/
 /dist/
-/assets/
 
 # Python droppings
 /venv/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,62 @@
+# Building the 3D Viewer with Docker
+
+We now support an alternate method of building and running the 3D Viewer: via Docker containers.
+
+Pros:
+   * The only dependency you need on your local MacOS system is the Docker Desktop. All other build
+     dependencies are managed inside Docker containers and installed automatically for you.
+   * The final product is a Docker image that will run on any system that has Docker installed –
+     whether Windows, MacOS, or Linux.
+
+Cons:
+   * You need to know a few Docker commands to run the built container and manage it. More
+     generally, Docker is a sophisticated development and deployment tool with an ecosystem of
+     commands all its own.
+   * The Docker approach is not so great for certain kinds of local development. Nominally, you
+     need to rebuild the container every time you want to make a change to the source. In practice,
+     there are ways of making at least the CSS/JS assets editable from outside the container, but
+     it's a bit tricky to set up.
+
+## Requirements
+
+We assume you're using MacOS, in which case your Terminal runs the `bash` shell needed to
+execute the `build-docker` script.
+
+You need [Docker Desktop](https://hub.docker.com/?overlay=onboarding) installed on your computer.
+Once it's installed, launch it to boot up a Docker server that will stay running on your system.
+This will also install the `docker` command-line tool for you the first time that it's run.
+
+During the installation and initial startup, you  will also be guided to create a Docker Hub
+account, so that you can publish Docker images that you create. Perhaps down the road we'll do
+this.
+
+## Using
+
+From a terminal at the top level of your directory, run the following: `./build-docker.sh`. Docker
+will take over and build your final container.
+
+   * If there are errors, simply fix them and rebuild. Rebuilds should be significantly faster, as
+     most of the installation work in the build container is cached by Docker.
+   * If something cached by Docker is causing persistent errors, you can use
+     `./build-docker.sh --no-cache` to force a rebuild from scratch.
+
+Once the build process runs to completion, run `docker images`. You should see an image tagged
+`botd3d-viewer:latest`, ready to run.
+
+To run the container: `docker run -d -p 8080:80 --name 3dViewer botd3d-viewer:latest`. Then point
+your browser to [http://localhost:8080/](http://localhost:8080).
+
+Some useful Docker commands:
+
+   * To see what's running: `docker ps`. You should see a container called '3dViewer' running off of
+     the image 'botd3d-viewer:latest', and for ports you should see something like
+     `0.0.0.0:8080->80/tcp` showing that the web server is listening on the host's port 8080.
+   * To launch a shell inside the running container for debugging:
+     `docker exec -it 3dViewer /bin/sh`. The web distribution is installed at
+     `/usr/share/nginx/html`, and the web server configuration is at
+     `/etc/nginx/nginx.conf`.
+   * To stop and delete the container: `docker stop 3dviewer` followed by `docker rm 3dviewer`.
+     The image will still be available, though.
+   * To extract the web distribution from the running container:
+     `docker cp 3dViewer:/usr/share/nginx/html ./dist`. Then look inside the `dist/` subdirectory
+     for the files.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.8-buster
+
+WORKDIR /home
+RUN apt-get update \
+    && apt-get install -y xmlstarlet openjdk-11-jre-headless \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /home
+RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
+
+COPY assets /home/assets
+COPY src /home/src
+COPY static /home/static
+COPY tools /home/tools
+COPY *.py /home/
+
+RUN python3 build.py -v
+
+FROM nginx:1.17-alpine
+
+WORKDIR /home
+COPY --from=0 /home/dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -173,3 +173,8 @@ full XML schema for our data is located in the `tools/schema/` directory.
      that errors can be caught and corrected quickly.
    * For now, we don't support live reload. So, every time you make a change and rerun the build,
      you'll need to reload the browser to see it.
+
+## Docker
+
+We are experimenting with an alternate development setup that uses Docker. If you want to try it
+out, you can skip the Requirements and Setup above, and just see [DOCKER.md](DOCKER.md) for details.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Once your virtualenv is active, install the Python library dependencies thus:
 ### Assets
 
 We manage our 3D models and hieroglyphic source material in a separate repo from this project. You
-will have the easiest time if you place the assets repo alongside this repo's folder, i.e. so that
-the two share the same parent directory. You can place it elsewhere if you wish, but in that case
-you will need to pass the build script an option to tell it where to find the assets.
+will have the easiest time if you place the assets repo _inside_ this repo's top-level directory.
+You can place it elsewhere if you wish, but in that case you will need to pass the build script an
+option to tell it where to find the assets.
 
 There are also a set of static "assets" inside this repo that are specifically for use by this
 website – CSS, web fonts, and Javascript. When you build the project, they will be installed along

--- a/README.md
+++ b/README.md
@@ -29,16 +29,13 @@ You must have:
   this:
    * Via homebrew: `brew install python3`
    * Via the standard [Python 3 distribution for MacOS](https://www.python.org/downloads/)
-* The **Java Development Kit (JDK)**. Again, two ways to install:
+* A suitable **Java Development Kit (JDK)**, version 8 or later. Again, two ways to install:
    * Via homebrew: `brew cask install java` (installs OpenJDK)
    * Via the standard [Oracle JDK SE distribution for MacOS](https://www.oracle.com/technetwork/java/javase/downloads/jdk13-downloads-5672538.html).
      Oracle provides a number of professional options for downloads, but the free(est) edition
      (Standard Edition, aka SE) will do.
 * **XML Starlet**, a suite of tools for XML validation and hacking. Install via Homebrew:
   `brew install xmlstarlet`.
-* **Saxon**, a powerful tool for XML processing. Like with Java, there are several professional
-  versions available, but we'll assume you're using the free edition (Home Edition, aka HE). Install
-  via Homebrew: `brew install saxon`.
 * The Python Classical Languages Toolkit, which we will install below as part of setup.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ You must have:
 
 ### Python Libraries
 
-You will need to install at least one Python library to build the website. We recommend
-installing it in a Python "virtualenv" that will keep your project's Python libraries separate
-from other projects so that they don't conflict.
+You will need to install at least one Python library, the Classical Languages Toolkit (CLTK), to
+build the website. We recommend installing it in a Python "virtualenv" that will keep your project's
+Python libraries separate from other projects so that they don't conflict.
 
 There are many ways to set up a virtualenv in Python, but here's how we do it. From the top of this
 repo, run the following: `python3 -m venv venv`. This will create a directory `venv/` in your

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t botd3d-viewer:latest . "$@"

--- a/build.py
+++ b/build.py
@@ -46,7 +46,7 @@ def xslTransform(config, stylesheet, src, dest, includes=False):
     if includes:
         description += ', with XIncludes'
     log.debug('Transform: %s -> (%s) -> %s', src, description, dest)
-    cmd = [config.saxonpath, '-xsl:' + stylesheet, '-s:' + src, '-o:' + dest]
+    cmd = ['java', '-jar', 'tools/saxon9he.jar', '-xsl:' + stylesheet, '-s:' + src, '-o:' + dest]
     if includes:
         cmd.append('-xi')
     if config.verbose:
@@ -193,7 +193,6 @@ def getConfig(args):
     parser.add_argument('--distdir', help='where final build output is written', default='dist')
     parser.add_argument('--builddir', help='where intermediate build output is written', default='build')
     parser.add_argument('--sitexml', help='location of site XML definition', default='src/site.xml')
-    parser.add_argument('--saxonpath', help='location of Saxon XSLT processor')
     parser.add_argument('---xmlstarletpath', help='location of XML Starlet, used for XML Include/Schema processing')
     parser.add_argument('--no-val', dest='validate', action='store_false', help='Skip XML validation step', default=True)
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='Verbose output')
@@ -207,10 +206,6 @@ def getConfig(args):
         parser.error('Cannot set build directory to root!')
 
     # Fill in defaults for tool locations if necessary.
-    try:
-        resolveToolLocation(config, 'saxonpath', 'saxon')
-    except NoSuchTool:
-        parser.error('Saxon not found. Install Saxon with Homebrew or specify the location of the executable using --saxonpath.')
     try:
         resolveToolLocation(config, 'xmlstarletpath', 'xmlstarlet')
     except NoSuchTool:

--- a/build.py
+++ b/build.py
@@ -324,6 +324,7 @@ def main(args):
         validateSiteSchema(config)
     prepareDistDir(config)
     buildSite(config)
+    return 0
 
 
 if __name__ == '__main__':

--- a/build.py
+++ b/build.py
@@ -189,7 +189,7 @@ def getConfig(args):
     Currently, only comamnd-line configuration is supported.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--assetsdir', help='where model assets are stored', default='../assets')
+    parser.add_argument('--assetsdir', help='where model assets are stored', default='assets')
     parser.add_argument('--distdir', help='where final build output is written', default='dist')
     parser.add_argument('--builddir', help='where intermediate build output is written', default='build')
     parser.add_argument('--sitexml', help='location of site XML definition', default='src/site.xml')


### PR DESCRIPTION
This might potentially make development a bit easier, as instead of having to install a bunch of dependencies on your host system, you can just install Docker and use it to automatically build the rest.

Also:
* Checking Saxon into the local repo so we don't need to install it as a dependency anymore. Just Java as a dependency is enough.
* Relocating the default location of assets to be inside of, rather than alongside, the 3dViewer repo. (See commit comment for why.)
