### PR TITLE
Camera rot sphere

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -329,10 +329,22 @@ ModelController.prototype.loadModel = function loadModel(modelname) {
 ModelController.prototype.moveCamera = function moveCamera(selection){
   var boundingbox = new THREE.Box3();
   boundingbox.setFromObject(selection);
-  //gets the center of the bounding box and puts it in the controls target
-  boundingbox.getCenter(this.viewer.controls.target);
-  this.viewer.camera.lookAt(this.viewer.controls.target)
-  //I don'tthink this object persists in the scene because I don't ever attach it.
+  var projection_vector = new THREE.Vector3();
+  var camera_pos = new THREE.Vector3();
+  camera_pos.copy(this.viewer.camera.position)
+  //get the vector between the centerpoint of the clicked object 
+  //and the center of the camera's orbit.
+  //and normalize it.
+  boundingbox.getCenter(projection_vector);
+  projection_vector.sub(this.viewer.controls.target);
+  projection_vector.normalize();
+  //get the radius of the sphere the camera is orbiting.
+  var radius_sphere = camera_pos.distanceTo(this.viewer.controls.target);
+  //multiply the radius by the normalized vector to set the new camera position.
+  projection_vector.multiplyScalar(radius_sphere);
+  this.viewer.camera.position.copy(projection_vector);
+  this.viewer.controls.update();
+  
 }
 ModelController.prototype.onViewerClick = function onViewerClick(e) {
   const obj = this.viewer.intersectObject(e);


### PR DESCRIPTION
Added camera rotation methods to the javascript which move the camera when you click on a link and click on an area of interest. 
-Clicking on an area uses the surface normal of the face you clicked along with an arbitrary altitude to calculate the position of the camera for viewing that area.
-Clicking on the link uses the vector between the centre of the parent of the object of interest to get a location on the sphere created by the radius between the camera and the centre of the object which is the target of rotation.
Neither solution is optimal but will have to work for now. 
-The surface normal solution works better, but can't be used for situations where you don't have a surface that has been clicked.
-The sphere rotation works in both cases, but sometimes produces odd angles if the object is especially tall.
Ideally we could add  a list of optimal positions to the xml but this is a bit more labor intensive than what I wanted for now.