### PR TITLE
Allow assets/ to be a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 launch.json
 
 # External assets repo
-assets/
+/assets
 
 # Build output directories
 /build/


### PR DESCRIPTION
This is so that I can use this setup with Box Sync, which copies assets to a different directory.